### PR TITLE
Gentoo: repository must be enabled/added

### DIFF
--- a/src/sections/downloads-v3/linux-gentoo.marko
+++ b/src/sections/downloads-v3/linux-gentoo.marko
@@ -12,6 +12,7 @@
         <p>
             For example, 
             <pre><code class="bash">emerge eselect-repository dev-vcs/git
+eselect repository enable usenet-overlay
 emerge --sync usenet-overlay
 emerge sonarr</code></pre>
         </p>


### PR DESCRIPTION
The usenet-overlay repository must be enabled (added) before it can be synced.