### PR TITLE
Gentoo now includes sonarr

### DIFF
--- a/src/sections/downloads-v3/linux-gentoo.marko
+++ b/src/sections/downloads-v3/linux-gentoo.marko
@@ -2,20 +2,11 @@
     <maintained-by><a href="https://github.com/xartin/gentoo-overlay">xartin</a></maintained-by>
     <install-step title="Introduction">
         <p>
-            The Gentoo Linux <a href="https://github.com/xartin/gentoo-overlay">Ebuild Overlay</a> offers a sonarr package that can be installed using Gentoo portage.
+            <a href="https://packages.gentoo.org/packages/www-apps/sonarr">Gentoo Linux includes sonarr</a> so it can be installed using Gentoo portage.
         </p>
     </install-step>
     <install-step num="1" title="Install Sonarr">
-        <p>
-            The easiest method to add this overlay for sonarr to any Gentoo Linux install is using <a href="https://wiki.gentoo.org/wiki/Eselect/Repository">eselect repository</a> to provide sonarr package install files.
-        </p>
-        <p>
-            For example, 
-            <pre><code class="bash">emerge eselect-repository dev-vcs/git
-eselect repository enable usenet-overlay
-emerge --sync usenet-overlay
-emerge sonarr</code></pre>
-        </p>
+        <pre><code class="bash">emerge www-apps/sonarr</code></pre>
     </install-step>
     <install-step num="2" title="Start Sonarr">
         <pre><code class="bash">systemctl daemon-reload


### PR DESCRIPTION
Gentoo now includes sonarr package so the use of an overlay is no longer necessary or recommended.

See: https://github.com/gentoo/gentoo/commit/7a6bfbbb5b55ba4e6986443e47d230e50db3c080