### PR TITLE
update discord link / correct macos text

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,7 +628,7 @@ service sonarr start</code></pre>
                             <dt><span class="step">3</span>Self-sign Sonarr</dt>
                             <dd>
                                 <p>
-                                    Self-sign Sonarr <code>codesign --force --deep -s - Sonarr.app</code>
+                                    Open Terminal and run <code>codesign --force --deep -s - Sonarr.app</code>
                                 </p>
                             </dd>
                             <dt><span class="step">4</span>Start Sonarr</dt>
@@ -813,7 +813,7 @@ service sonarr start</code></pre>
                         </p>
                     </div>
                 </a>
-                <a class="col-sm-3" href="https://discord.gg/73QUuf3bgA" target="_blank">
+                <a class="col-sm-3" href="https://discord.sonarr.tv" target="_blank">
                     <div class="text">
                         <i class="fab fa-discord fa-2x"></i>
                         <h4>Discord</h4>

--- a/src/sections/support.marko
+++ b/src/sections/support.marko
@@ -29,7 +29,7 @@
         </div>
     </a>
 
-    <a class="col-sm-3" href="https://discord.gg/73QUuf3bgA" target="_blank">
+    <a class="col-sm-3" href="https://discord.sonarr.tv" target="_blank">
         <div class="text">
             <i class="fab fa-discord fa-2x"></i>
             <h4>Discord</h4>


### PR DESCRIPTION
Update the discord link and capture a change to MacOS text that wasn't picked up from PR #26 (wasn't rebuilt after marko change)