### PR TITLE
Change apt-key to gpg

### DIFF
--- a/css/bootstrap-overrides.css
+++ b/css/bootstrap-overrides.css
@@ -15,7 +15,7 @@
   .navbar-static-top .container,
   .navbar-fixed-top .container,
   .navbar-fixed-bottom .container {
-    width: 940px; } }
+    width: 960px; } }
 /*
   Bootstrap 3 by default keeps the navbar visible on tablets.
   From here onwards it's to get the navbar to collapse starting on 991px - tablets

--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
                                         <dt><span class="step">2</span>Add the Sonarr repository</dt>
                                         <dd>
                                             <div>
-                                                Execute the below three commands in your terminal. <br>
+                                                Execute the three commands show below in your terminal.<br>
                                                 Note: the packages should work on newer Debian versions too but we only provide packages for the ones listed below.
                                             </div>
                                             <dl>
@@ -371,7 +371,7 @@ sudo apt update</code></pre>
                                         <dt><span class="step">2</span>Add the Sonarr repository</dt>
                                         <dd>
                                             <div>
-                                                Execute the below three commands in your terminal. <br>
+                                                Execute the three commands show below in your terminal.<br>
                                                 Note: the packages should work on newer Ubuntu versions too but we only provide packages for the ones listed below.
                                             </div>
                                             <dl>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="css/bootstrap-overrides.css?v=0032cb25c1f3202a92ff30daf9c072d5">
+    <link rel="stylesheet" type="text/css" href="css/bootstrap-overrides.css?v=b8a10d1b2e6e77cc87ab1bcb5be6f6cd">
     <link rel="stylesheet" type="text/css" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/github.min.css">
     <link rel="stylesheet" type="text/css" href="css/theme.css?v=604dd013f58b7955e9a6479541ee5fdd">
@@ -272,25 +272,26 @@
                                         <dt><span class="step">2</span>Add the Sonarr repository</dt>
                                         <dd>
                                             <div>
+                                                Execute the below three commands in your terminal. <br>
                                                 Note: the packages should work on newer Debian versions too but we only provide packages for the ones listed below.
                                             </div>
                                             <dl>
                                                 <dt>Debian 8 "jessie" <span class="arch">(i386, amd64, armhf)</span></dt>
                                                 <dd>
-                                                    <pre><code class="bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
-echo "deb https://apt.sonarr.tv/debian jessie main" | sudo tee /etc/apt/sources.list.d/sonarr.list
+                                                    <pre><code class="bash">sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --no-default-keyring --keyring /usr/share/keyrings/sonarr.gpg --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
+echo "deb [signed-by=/usr/share/keyrings/sonarr.gpg] https://apt.sonarr.tv/debian jessie main" | sudo tee /etc/apt/sources.list.d/sonarr.list
 sudo apt update</code></pre>
                                                 </dd>
                                                 <dt>Debian 9 "stretch" <span class="arch">(i386, amd64, armhf)</span></dt>
                                                 <dd>
-                                                    <pre><code class="bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
-echo "deb https://apt.sonarr.tv/debian stretch main" | sudo tee /etc/apt/sources.list.d/sonarr.list
+                                                    <pre><code class="bash">sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --no-default-keyring --keyring /usr/share/keyrings/sonarr.gpg --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
+echo "deb [signed-by=/usr/share/keyrings/sonarr.gpg] https://apt.sonarr.tv/debian stretch main" | sudo tee /etc/apt/sources.list.d/sonarr.list
 sudo apt update</code></pre>
                                                 </dd>
                                                 <dt>Debian 10 "buster" <span class="arch">(i386, amd64, armhf, arm64)</span></dt>
                                                 <dd>
-                                                    <pre><code class="bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
-echo "deb https://apt.sonarr.tv/debian buster main" | sudo tee /etc/apt/sources.list.d/sonarr.list
+                                                    <pre><code class="bash">sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --no-default-keyring --keyring /usr/share/keyrings/sonarr.gpg --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
+echo "deb [signed-by=/usr/share/keyrings/sonarr.gpg] https://apt.sonarr.tv/debian buster main" | sudo tee /etc/apt/sources.list.d/sonarr.list
 sudo apt update</code></pre>
                                                 </dd>
                                             </dl>
@@ -370,25 +371,26 @@ sudo apt update</code></pre>
                                         <dt><span class="step">2</span>Add the Sonarr repository</dt>
                                         <dd>
                                             <div>
+                                                Execute the below three commands in your terminal. <br>
                                                 Note: the packages should work on newer Ubuntu versions too but we only provide packages for the ones listed below.
                                             </div>
                                             <dl>
                                                 <dt>Ubuntu 16.04 "xenial" <span class="arch">(i386, amd64, armhf)</span></dt>
                                                 <dd>
-                                                    <pre><code class="bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
-echo "deb https://apt.sonarr.tv/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/sonarr.list
+                                                    <pre><code class="bash">sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --no-default-keyring --keyring /usr/share/keyrings/sonarr.gpg --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
+echo "deb [signed-by=/usr/share/keyrings/sonarr.gpg] https://apt.sonarr.tv/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/sonarr.list
 sudo apt update</code></pre>
                                                 </dd>
                                                 <dt>Ubuntu 18.04 "bionic" <span class="arch">(i386, amd64, armhf)</span></dt>
                                                 <dd>
-                                                    <pre><code class="bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
-echo "deb https://apt.sonarr.tv/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/sonarr.list
+                                                    <pre><code class="bash">sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --no-default-keyring --keyring /usr/share/keyrings/sonarr.gpg --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
+echo "deb [signed-by=/usr/share/keyrings/sonarr.gpg] https://apt.sonarr.tv/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/sonarr.list
 sudo apt update</code></pre>
                                                 </dd>
                                                 <dt>Ubuntu 20.04 "focal" <span class="arch">(i386, amd64, armhf, arm64)</span></dt>
                                                 <dd>
-                                                    <pre><code class="bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
-echo "deb https://apt.sonarr.tv/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/sonarr.list
+                                                    <pre><code class="bash">sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --no-default-keyring --keyring /usr/share/keyrings/sonarr.gpg --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
+echo "deb [signed-by=/usr/share/keyrings/sonarr.gpg] https://apt.sonarr.tv/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/sonarr.list
 sudo apt update</code></pre>
                                                 </dd>
                                             </dl>

--- a/src/sections/downloads-v3/linux-debian-template.marko
+++ b/src/sections/downloads-v3/linux-debian-template.marko
@@ -25,14 +25,15 @@
     </install-step>
     <install-step num="2" title="Add the Sonarr repository">
         <div>
+            Execute the below three commands in your terminal. <br/>
             Note: the packages should work on newer ${input.vendor_title} versions too but we only provide packages for the ones listed below.
         </div>
         <dl>
             <for|distro| of=input.distros.filter(v => !v.hidden)>
             <dt>${distro.title} <span class="arch">(${distro.archs})</span></dt>
             <dd>
-                <pre><code class="bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
-echo "deb https://apt.sonarr.tv/${input.vendor} ${distro.code} main" | sudo tee /etc/apt/sources.list.d/sonarr.list
+                <pre><code class="bash">sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --no-default-keyring --keyring /usr/share/keyrings/sonarr.gpg --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8
+echo "deb [signed-by=/usr/share/keyrings/sonarr.gpg] https://apt.sonarr.tv/${input.vendor} ${distro.code} main" | sudo tee /etc/apt/sources.list.d/sonarr.list
 sudo apt update</code></pre>
             </dd>
             </for>

--- a/src/sections/downloads-v3/linux-debian-template.marko
+++ b/src/sections/downloads-v3/linux-debian-template.marko
@@ -25,7 +25,7 @@
     </install-step>
     <install-step num="2" title="Add the Sonarr repository">
         <div>
-            Execute the below three commands in your terminal. <br/>
+            Execute the three commands show below in your terminal.<br/>
             Note: the packages should work on newer ${input.vendor_title} versions too but we only provide packages for the ones listed below.
         </div>
         <dl>


### PR DESCRIPTION
Switched the install instructions from apt-key (deprecated) to gpg.
Also made the width slightly larger otherwise the `--` from recv-keys split onto two lines and looked odd :)