### PR TITLE
split debian install command into two commands

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="css/bootstrap-overrides.css?v=37a2fe284eb88048394dd5c9a08b9623">
+    <link rel="stylesheet" type="text/css" href="css/bootstrap-overrides.css?v=b8a10d1b2e6e77cc87ab1bcb5be6f6cd">
     <link rel="stylesheet" type="text/css" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/github.min.css">
-    <link rel="stylesheet" type="text/css" href="css/theme.css?v=d41d8cd98f00b204e9800998ecf8427e">
+    <link rel="stylesheet" type="text/css" href="css/theme.css?v=e77e55142f707c997a867e307951afc0">
     <link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css">
     <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/animatecss/3.2.0/animate.min.css" media="screen, projection">
     <link rel="icon" type="image/ico" href="img/favicon.ico">
@@ -268,9 +268,11 @@
                                                 If you need to correct these after installation, please re-run the installation script.
                                             </div>
                                             <h5>curl</h5>
-                                            <pre><code class="bash">curl -o- https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh | sudo bash</code></pre>
+                                            <pre><code class="bash">curl -o install-sonarr.sh https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh
+sudo bash install-sonarr.sh</code></pre>
                                             <h5>wget</h5>
-                                            <pre><code class="bash">wget -qO- https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh | sudo bash</code></pre>
+                                            <pre><code class="bash">wget -qO install-sonarr.sh https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh
+sudo bash install-sonarr.sh</code></pre>
                                         </dd>
                                         <dt><span class="step">2</span>View Sonarr</dt>
                                         <dd>
@@ -337,9 +339,11 @@
                                                 If you need to correct these after installation, please re-run the installation script.
                                             </div>
                                             <h5>curl</h5>
-                                            <pre><code class="bash">curl -o- https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh | sudo bash</code></pre>
+                                            <pre><code class="bash">curl -o install-sonarr.sh https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh
+sudo bash install-sonarr.sh</code></pre>
                                             <h5>wget</h5>
-                                            <pre><code class="bash">wget -qO- https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh | sudo bash</code></pre>
+                                            <pre><code class="bash">wget -qO install-sonarr.sh https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh
+sudo bash install-sonarr.sh</code></pre>
                                         </dd>
                                         <dt><span class="step">2</span>View Sonarr</dt>
                                         <dd>
@@ -825,13 +829,13 @@ service sonarr start</code></pre>
     </footer>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="js/tab-loader.js?v=0b6b7566a47c643cdeadfbbe3ca9bf79"></script>
+    <script src="js/tab-loader.js?v=fb0780ed4d2800d14c59a61fa57d57c2"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/highlight.min.js"></script>
     <script>
         hljs.initHighlightingOnLoad();
     </script>
-    <script src="js/theme.js?v=85693f7f35c872717ee514c10ca38fdc"></script>
-    <script type="text/javascript" src="js/index-slider.js?v=072006930bd52788bb7ab0a7d16861f7"></script>
+    <script src="js/theme.js?v=453b4ff1a4f41c49315a28f79aa5ea83"></script>
+    <script type="text/javascript" src="js/index-slider.js?v=48ba37f65a8c9499e4833ad1924fccb7"></script>
     <script type="text/javascript">
         if (window.location.hash.toLocaleLowerCase() === "#donate") {
             window.location.replace("https://sonarr.tv/donate");

--- a/src/sections/downloads/linux-debian-template.marko
+++ b/src/sections/downloads/linux-debian-template.marko
@@ -23,9 +23,11 @@ import ManualTemplate from './linux-manual-template.marko';
             If you need to correct these after installation, please re-run the installation script.
         </alert>
         <h5>curl</h5>
-        <pre><code class="bash">curl -o- https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh | sudo bash</code></pre>
+        <pre><code class="bash">curl -o install-sonarr.sh https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh
+sudo bash install-sonarr.sh</code></pre>
         <h5>wget</h5>
-        <pre><code class="bash">wget -qO- https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh | sudo bash</code></pre>
+        <pre><code class="bash">wget -qO install-sonarr.sh https://raw.githubusercontent.com/Sonarr/Sonarr/develop/distribution/debian/install.sh
+sudo bash install-sonarr.sh</code></pre>
     </install-step>
     <install-step num="2" title="View Sonarr">
         <p>


### PR DESCRIPTION

Fixes issues on Ubunutu 25.10 where the pipe'd bash script is no onger able to connect to the terminal and get the user input